### PR TITLE
Upgrade script to use Helm v3 env variables

### DIFF
--- a/starter.sh
+++ b/starter.sh
@@ -51,16 +51,17 @@ COMMAND=${PASSTHRU[0]}
 
 if [ "$COMMAND" == "fetch" ]; then
     REPO=${PASSTHRU[1]}
-    cd ${HELM_PATH_STARTER}
+    mkdir -p ${HELM_DATA_HOME}/starters
+    cd ${HELM_DATA_HOME}/starters
     git clone ${REPO} --quiet
     cd $OLDPWD
     exit 0
 elif [ "$COMMAND" == "list" ]; then
-    ls -A1 ${HELM_PATH_STARTER}
+    ls -A1 ${HELM_DATA_HOME}/starters
     exit 0
 elif [ "$COMMAND" == "delete" ]; then 
     STARTER=${PASSTHRU[1]}
-    rm -rf ${HELM_PATH_STARTER}/${STARTER}
+    rm -rf ${HELM_DATA_HOME}/starters/${STARTER}
     exit 0
 else
     echo "Error: Invalid command, must be one of 'fetch', 'list', or 'delete'"


### PR DESCRIPTION
## Issue

Using Helm v3 the env var HELM_PATH_STARTER is no longer being set, breaking this plugin. 

```
$ helm version --short
v3.4.1+gc4e7485

$ helm env
HELM_BIN="helm"
HELM_CACHE_HOME="/home/mark/.cache/helm"
HELM_CONFIG_HOME="/home/mark/.config/helm"
HELM_DATA_HOME="/home/mark/.local/share/helm"
HELM_DEBUG="false"
HELM_KUBEAPISERVER=""
HELM_KUBEASGROUPS=""
HELM_KUBEASUSER=""
HELM_KUBECONTEXT=""
HELM_KUBETOKEN=""
HELM_MAX_HISTORY="10"
HELM_NAMESPACE="websites"
HELM_PLUGINS="/home/mark/.local/share/helm/plugins"
HELM_REGISTRY_CONFIG="/home/mark/.config/helm/registry.json"
HELM_REPOSITORY_CACHE="/home/mark/.cache/helm/repository"
HELM_REPOSITORY_CONFIG="/home/mark/.config/helm/repositories.yaml"
```

## Summary of change

The FAQ describes the changes introduced by Helm V3

https://helm.sh/docs/faq/

This PR replaces the undocumented **HELM_PATH_STARTER** variable with **$HELM_DATA_HOME/starters**. Helm v2 is no longer supported, which  implies this plugin has no need to be backwardly compatible (Just make it work).