### PR TITLE
"master" is not always the main branch

### DIFF
--- a/starter.sh
+++ b/starter.sh
@@ -62,7 +62,7 @@ if [ "$COMMAND" == "fetch" ]; then
 elif [ "$COMMAND" == "update" ]; then
     STARTER=${PASSTHRU[1]}
     cd ${HELM_DATA_HOME}/starters/${STARTER}
-    git pull origin master --quiet
+    git pull origin $(git rev-parse --abbrev-ref HEAD) --quiet
     exit 0
 elif [ "$COMMAND" == "list" ]; then
     ls -A1 ${HELM_DATA_HOME}/starters


### PR DESCRIPTION
Allow update of starter git repositories not using "master" as main branch.

Removes the hard coded "master" branch name from the update command