### PR TITLE
feature/support specific starter versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Example helm starters:
 
 ## Usage
 
-* `helm starter fetch GITURL`: Clones a bare helm starter repo into `$HELM_HOME/starters`
+* `helm starter fetch GITURL [VERSION]`: Clones a bare helm starter repo into `$HELM_HOME/starters`
 * `helm starter list`: Lists all the starters in `$HELM_HOME/starters`
-* `helm starter update NAME`: Refresh an installed Helm starter
+* `helm starter update NAME [VERSION]`: Refresh an installed Helm starter or update to a specific version
 * `helm starter delete NAME`: Delete `name` from `$HELM_HOME/starters`
 * `helm starter inspect NAME`: Print out a starter's readme
 * `helm starter --help`: print help

--- a/starter.sh
+++ b/starter.sh
@@ -11,12 +11,14 @@ cat << EOF
 Fetch, list, and delete helm starters from github.
 
 Available Commands:
-    helm starter fetch GITURL       Install a bare Helm starter from Github (e.g git clone)
-    helm starter list               List installed Helm starters
-    helm starter update NAME        Refresh an installed Helm starter
-    helm starter delete NAME        Delete an installed Helm starter
-    helm starter inspect NAME       Print out a starter's readme
-    --help                          Display this text
+    helm starter fetch GITURL [VERSION]   Install a bare Helm starter from Github (e.g git clone)
+					  Optionally specify a version (e.g. a git tag)
+    helm starter list                     List installed Helm starters
+    helm starter update NAME [VERSION]    Refresh an installed Helm starter
+                                          Optionally specify a version (e.g. a git tag)
+    helm starter delete NAME              Delete an installed Helm starter
+    helm starter inspect NAME             Print out a starter's readme
+    --help                                Display this text
 EOF
 }
 
@@ -56,15 +58,23 @@ mkdir -p ${HELM_DATA_HOME}/starters
 
 if [ "$COMMAND" == "fetch" ]; then
     REPO=${PASSTHRU[1]}
+    VERSION=${PASSTHRU[2]}
     cd ${HELM_DATA_HOME}/starters
-    git clone ${REPO} --quiet
+    if [ -z "$VERSION" ]; then
+        git clone ${REPO} --quiet
+    else
+        git -c advice.detachedHead=false clone ${REPO} --quiet --branch ${VERSION}
+    fi
     exit 0
 elif [ "$COMMAND" == "update" ]; then
     STARTER=${PASSTHRU[1]}
+    VERSION=${PASSTHRU[2]:-"HEAD"}
     cd ${HELM_DATA_HOME}/starters/${STARTER}
     git pull origin $(git rev-parse --abbrev-ref HEAD) --quiet
+    git checkout ${VERSION} --quiet
     exit 0
 elif [ "$COMMAND" == "list" ]; then
+    # TODO: print also the checked out version, perhaps using "git describe --tags"?
     ls -A1 ${HELM_DATA_HOME}/starters
     exit 0
 elif [ "$COMMAND" == "delete" ]; then 

--- a/starter.sh
+++ b/starter.sh
@@ -74,8 +74,15 @@ elif [ "$COMMAND" == "update" ]; then
     git checkout ${VERSION} --quiet
     exit 0
 elif [ "$COMMAND" == "list" ]; then
-    # TODO: print also the checked out version, perhaps using "git describe --tags"?
-    ls -A1 ${HELM_DATA_HOME}/starters
+    cd ${HELM_DATA_HOME}/starters
+    printf "%-20s   %-10s\n" NAME VERSION
+    for STARTER in *; do
+	if [ -d "$STARTER" ]; then
+	    cd ${HELM_DATA_HOME}/starters/${STARTER}
+	    VERSION=$(git describe --tags)
+	    printf "%-20s   %-10s\n" ${STARTER} ${VERSION}
+	fi
+    done
     exit 0
 elif [ "$COMMAND" == "delete" ]; then 
     STARTER=${PASSTHRU[1]}


### PR DESCRIPTION
Support pulling and updating specific starter versions

As an enhancement it is optionally possible to specify a version for a starter. This version must correspond to a git tag of the starters git repository. The specification of the version is possible on starter commands `fetch` and `update`, the command `list` shows the starter version in use.
